### PR TITLE
make tuple translation configurable

### DIFF
--- a/src/main/scala/scala/js/gen/js/GenTupleOps.scala
+++ b/src/main/scala/scala/js/gen/js/GenTupleOps.scala
@@ -6,32 +6,51 @@ trait GenTupleOps extends GenBase {
   val IR: TupleOpsExp
   import IR._
 
+  // flag that manages how tuples are translated into JS
+  // by default they are translated to JS objects with fields
+  // named '_1', '_2' and so on
+  // for interoperatbility one can override this setting so that
+  // tuples are translated to arrays
+  def tupleAsArrays = false
+
+  def access(idx: Int): String =
+    if(tupleAsArrays)
+      s"[${idx-1}]"
+    else
+      s"._$idx"
+
+  def build(elems: Exp[_]*): String =
+    if(tupleAsArrays) {
+      "[" + elems.map(quote _).mkString(",") + "]"
+    } else {
+      val withIdx = elems.zipWithIndex.map {
+        case (elem, idx) => "_" + (idx + 1) + ":" + quote(elem)
+      }
+      "{" + withIdx.mkString(",") + "}"
+    }
+
   override def emitNode(sym: Sym[Any], rhs: Def[Any]) = rhs match {
-    case ETuple2(a,b)  =>
-      emitValDef(sym, "{_1:"+ quote(a) + ",_2:" + quote(b) + "}")
-    case Tuple2Access1(t) => emitValDef(sym, quote(t) + "._1")
-    case Tuple2Access2(t) => emitValDef(sym, quote(t) + "._2")
+    case ETuple2(a,b)        => emitValDef(sym, build(a, b))
+    case Tuple2Access1(t)    => emitValDef(sym, quote(t) + access(1))
+    case Tuple2Access2(t)    => emitValDef(sym, quote(t) + access(2))
 
-    case ETuple3(a,b,c)  =>
-      emitValDef(sym, "{_1:"+ quote(a) + ",_2:" + quote(b) + ",_3:" + quote(c) + "}")
-    case Tuple3Access1(t) => emitValDef(sym, quote(t) + "._1")
-    case Tuple3Access2(t) => emitValDef(sym, quote(t) + "._2")
-    case Tuple3Access3(t) => emitValDef(sym, quote(t) + "._3")
+    case ETuple3(a,b,c)      => emitValDef(sym, build(a, b, c))
+    case Tuple3Access1(t)    => emitValDef(sym, quote(t) + access(1))
+    case Tuple3Access2(t)    => emitValDef(sym, quote(t) + access(2))
+    case Tuple3Access3(t)    => emitValDef(sym, quote(t) + access(3))
 
-    case ETuple4(a,b,c,d)  =>
-      emitValDef(sym, "{_1:"+ quote(a) + ",_2:" + quote(b) + ",_3:" + quote(c) + ",_4:" + quote(d) + "}")
-    case Tuple4Access1(t) => emitValDef(sym, quote(t) + "._1")
-    case Tuple4Access2(t) => emitValDef(sym, quote(t) + "._2")
-    case Tuple4Access3(t) => emitValDef(sym, quote(t) + "._3")
-    case Tuple4Access4(t) => emitValDef(sym, quote(t) + "._4")
+    case ETuple4(a,b,c,d)    => emitValDef(sym, build(a, b, c, d))
+    case Tuple4Access1(t)    => emitValDef(sym, quote(t) + access(1))
+    case Tuple4Access2(t)    => emitValDef(sym, quote(t) + access(2))
+    case Tuple4Access3(t)    => emitValDef(sym, quote(t) + access(3))
+    case Tuple4Access4(t)    => emitValDef(sym, quote(t) + access(4))
 
-    case ETuple5(a,b,c,d,e)  =>
-      emitValDef(sym, "{_1:"+ quote(a) + ",_2:" + quote(b) + ",_3:" + quote(c) + ",_4:" + quote(d) + ",_5:" + quote(e) + "}")
-    case Tuple5Access1(t) => emitValDef(sym, quote(t) + "._1")
-    case Tuple5Access2(t) => emitValDef(sym, quote(t) + "._2")
-    case Tuple5Access3(t) => emitValDef(sym, quote(t) + "._3")
-    case Tuple5Access4(t) => emitValDef(sym, quote(t) + "._4")
-    case Tuple5Access5(t) => emitValDef(sym, quote(t) + "._5")
+    case ETuple5(a,b,c,d,e)  => emitValDef(sym, build(a, b, c, d, e))
+    case Tuple5Access1(t)    => emitValDef(sym, quote(t) + access(1))
+    case Tuple5Access2(t)    => emitValDef(sym, quote(t) + access(2))
+    case Tuple5Access3(t)    => emitValDef(sym, quote(t) + access(3))
+    case Tuple5Access4(t)    => emitValDef(sym, quote(t) + access(4))
+    case Tuple5Access5(t)    => emitValDef(sym, quote(t) + access(5))
 
     case _ => super.emitNode(sym, rhs)
   }

--- a/src/test/scala/scala/js/TestTuple.scala
+++ b/src/test/scala/scala/js/TestTuple.scala
@@ -34,6 +34,12 @@ trait UnboxedQuoteProg { this: JS =>
   }
 }
 
+trait SimpleTupleProg { this: JS =>
+  def test(x: Rep[Any]): (Rep[Int], Rep[String], Rep[Boolean]) = {
+    (1, "2", true)
+  }
+}
+
 class TestTuple extends FileDiffSuite {
 
   val prefix = "test-out/"
@@ -76,6 +82,29 @@ class TestTuple extends FileDiffSuite {
       }
     }
     assertFileEqualsCheck(prefix+"unboxedquote")
+  }
+
+  def testObjectTranslation = {
+    withOutFile(prefix+"tuple-as-object") {
+      new SimpleTupleProg with JSExp { self =>
+        val codegen = new GenJS { val IR: self.type = self }
+        codegen.emitSource(test _, "main", new PrintWriter(System.out))
+      }
+    }
+    assertFileEqualsCheck(prefix+"tuple-as-object")
+  }
+
+  def testArrayTranslation = {
+    withOutFile(prefix+"tuple-as-array") {
+      new SimpleTupleProg with JSExp { self =>
+        val codegen = new GenJS {
+          val IR: self.type = self
+          override def tupleAsArrays = true
+        }
+        codegen.emitSource(test _, "main", new PrintWriter(System.out))
+      }
+    }
+    assertFileEqualsCheck(prefix+"tuple-as-array")
   }
 
 }

--- a/test-out/tuple-as-array.check
+++ b/test-out/tuple-as-array.check
@@ -1,0 +1,4 @@
+function main(x0) {
+var x1 = [1,"2",true];
+return x1
+}

--- a/test-out/tuple-as-object.check
+++ b/test-out/tuple-as-object.check
@@ -1,0 +1,4 @@
+function main(x0) {
+var x1 = {_1:1,_2:"2",_3:true};
+return x1
+}


### PR DESCRIPTION
One can choose whether tuples are translated to js objects or arrays
depending on how it is used.
This can be interesting when using js libraries that encode tuples as
arrays. For example I use this for the DSL I am writing to implement couchdb design documents in Scala 
For example, see [this test](https://github.com/gnieh/sohva/blob/master/sohva-dsl/src/test/scala/gnieh/sohva/dsl/test/TestDesigns.scala#L98) where the js function returns a two element array (of different types). Using a tuple in Scala makes it easier to typecheck without the overhead of defining a specific class that translates to an array.
