### PR TITLE
Solve an apparent name clash swith the current version of lms.

### DIFF
--- a/core/src/main/scala/scala/js/exp/ListOps2Exp.scala
+++ b/core/src/main/scala/scala/js/exp/ListOps2Exp.scala
@@ -4,7 +4,7 @@ import scala.js.language.ListOps2
 import scala.virtualization.lms.common.EffectExp
 
 trait ListOps2Exp extends ListOps2 with EffectExp {
-  def list_mkString2[A](l: Exp[List[A]], sep: Exp[String]) = ListMkString2(l, sep)
+  def list_mkString2[A](l: Exp[List[A]], sep: Exp[String]) = ListMkString2Prime(l, sep)
   def list_foreach[A : Manifest](l: Exp[List[A]], f: Exp[A] => Exp[Unit]) = {
     val a = fresh[A]
     val block = reifyEffects(f(a))
@@ -18,7 +18,7 @@ trait ListOps2Exp extends ListOps2 with EffectExp {
   }
   def list_size[A](l: Rep[List[A]]) = ListSize(l)
 
-  case class ListMkString2[A](l: Exp[List[A]], sep: Exp[String]) extends Def[String]
+  case class ListMkString2Prime[A](l: Exp[List[A]], sep: Exp[String]) extends Def[String]
   case class ListForeach[A](l: Exp[List[A]], a: Sym[A], b: Block[Unit]) extends Def[Unit]
   case class ListForeachWithIndex[A](l: Exp[List[A]], a: Sym[A], i: Sym[Int], b: Block[Unit]) extends Def[Unit]
   case class ListSize[A](l: Rep[List[A]]) extends Def[Int]

--- a/core/src/main/scala/scala/js/gen/js/GenListOps2.scala
+++ b/core/src/main/scala/scala/js/gen/js/GenListOps2.scala
@@ -8,7 +8,7 @@ trait GenListOps2 extends GenEffect with QuoteGen {
   import IR._
 
   override def emitNode(sym: Sym[Any], rhs: Def[Any]) = rhs match {
-    case ListMkString2(l, sep) =>
+    case ListMkString2Prime(l, sep) =>
       emitValDef(sym, q"$l.join($sep)")
     case ListForeach(l, a, b) =>
       stream.println(q"$l.forEach(function ($a) {")

--- a/core/src/main/scala/scala/js/gen/scala/GenListOps2.scala
+++ b/core/src/main/scala/scala/js/gen/scala/GenListOps2.scala
@@ -9,7 +9,7 @@ trait GenListOps2 extends ScalaGenEffect with QuoteGen {
   import IR._
 
   override def emitNode(sym: Sym[Any], rhs: Def[Any]) = rhs match {
-    case ListMkString2(l, sep) =>
+    case ListMkString2Prime(l, sep) =>
       emitValDef(sym, q"$l.mkString($sep)")
     case ListForeachWithIndex(l, a, i, b) =>
       stream.println(q"var $sym = $l.zipWithIndex.foreach { case ($a, $i) =>")


### PR DESCRIPTION
Dear Julien,

I needed the attached patch to get js-scala to compile with the latest github version of lms.  It could be that I'm missing something, since I'm not terribly experienced in Scala, lms and related stuff...

Thanks for taking a look...
Dominique
